### PR TITLE
Added globally visible ra_tls_create_report() to produce SGX report

### DIFF
--- a/nonsdk-ra-attester.c
+++ b/nonsdk-ra-attester.c
@@ -328,3 +328,14 @@ void do_remote_attestation
                                            attn_report);
     free_quote(quote); quote = NULL;
 }
+
+void ra_tls_create_report(
+    sgx_report_t* report
+)
+{
+    sgx_target_info_t target_info = {0, };
+    sgx_report_data_t report_data = {0, };
+    memset(report, 0, sizeof(*report));
+
+    create_report(&target_info, &report_data, report);
+}

--- a/ra-attester.h
+++ b/ra-attester.h
@@ -33,4 +33,8 @@ void create_key_and_x509_pem
     int* pem_cert_len,
     const struct ra_tls_options* opts
 );
+
+void ra_tls_create_report(
+    sgx_report_t* report
+);
 #endif

--- a/sgxsdk-ra-attester_t.c
+++ b/sgxsdk-ra-attester_t.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <string.h>
 
 #include <sgx_uae_service.h>
 
@@ -24,4 +25,15 @@ void do_remote_attestation
     assert(status == SGX_SUCCESS);
 
     ocall_remote_attestation(&report, opts, attn_report);
+}
+
+void ra_tls_create_report(
+    sgx_report_t* report
+)
+{
+    sgx_target_info_t target_info = {0, };
+    sgx_report_data_t report_data = {0, };
+    memset(report, 0, sizeof(*report));
+
+    sgx_create_report(&target_info, &report_data, report);
 }


### PR DESCRIPTION
Added `ra_tls_create_report()` which is a simple wrapper around `sgx_create_report()`. Available both under SGX SDK and non-SDK frameworks like Graphene.

This new function is globally visible, so it can be directly used by applications (e.g. Graphene apps) to get SGX report without the need for remote communication with IAS.