### PR TITLE
Builds python from source rather than importing alpine package

### DIFF
--- a/sgxlkl/https-server/buildenv.sh
+++ b/sgxlkl/https-server/buildenv.sh
@@ -7,4 +7,12 @@ PATH=/usr/sbin:/sbin:/usr/bin:/bin
 cd /home
 echo "http://dl-cdn.alpinelinux.org/alpine/v3.6/community" >> /etc/apk/repositories
 apk update
-apk add python
+apk add openssl
+apk add openssl-dev
+apk add make
+apk add build-base
+apk update && apk add ca-certificates wget && update-ca-certificates
+apk add openssl
+wget https://www.python.org/ftp/python/2.7.15/Python-2.7.15.tgz 
+tar -xvzf Python-2.7.15.tgz
+cd Python-2.7.15/ && ./configure && make && make install && mv python /usr/bin


### PR DESCRIPTION
Installs openssl and builds python from source rather than using the alpine package because the package relies on libressl which does not seem to be accepting self signed certificates, as noted in issue #8.